### PR TITLE
Export of build module into plugin (+ MPS 2020.2)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ install:
   - sudo apt-get install ant-optional
 
   # Install MPS
-  - wget https://download.jetbrains.com/mps/2020.1/MPS-2020.1.tar.gz
-  - tar -xvf MPS-2020.1.tar.gz
-  - mv 'MPS 2020.1' mps
+  - wget https://download.jetbrains.com/mps/2020.2/MPS-2020.2.tar.gz
+  - tar -xvf MPS-2020.2.tar.gz
+  - mv 'MPS 2020.2' mps
 
 env:
   - MPS_HOME=./mps

--- a/build.xml
+++ b/build.xml
@@ -195,6 +195,46 @@
       <zipfileset file="${basedir}/code/languages/org.mar9000.mps.ecmascript/runtime/org.mar9000.mps.ecmascript.runtime.msd" prefix="module" />
       <zipfileset dir="${build.tmp}/customProcessors/copyModels/code-languages-org.mar9000.mps.ecmascript-runtime-models" prefix="module/models" />
     </jar>
+    <mkdir dir="${build.tmp}/default/org.mar9000.mps.ecmascript.build.jar" />
+    <mkdir dir="${build.tmp}/default/org.mar9000.mps.ecmascript.build.jar/META-INF" />
+    <echoxml file="${build.tmp}/default/org.mar9000.mps.ecmascript.build.jar/META-INF/module.xml">
+      <module namespace="org.mar9000.mps.ecmascript.build" type="solution" uuid="22ffb846-45b3-4ef5-a9f4-a67794b30a86">
+        <dependencies>
+          <module ref="422c2909-59d6-41a9-b318-40e6256b250f(jetbrains.mps.ide.build)" kind="cl" />
+        </dependencies>
+        <uses>
+          <language id="l:798100da-4f0a-421a-b991-71f8c50ce5d2:jetbrains.mps.build" />
+          <language id="l:0cf935df-4699-4e9c-a132-fa109541cba3:jetbrains.mps.build.mps" />
+          <language id="l:3600cb0a-44dd-4a5b-9968-22924406419e:jetbrains.mps.build.mps.tests" />
+        </uses>
+        <classpath>
+          <entry path="." />
+        </classpath>
+        <sources jar="org.mar9000.mps.ecmascript.build-src.jar" descriptor="org.mar9000.mps.ecmascript.build.msd" />
+      </module>
+    </echoxml>
+    <jar destfile="${build.layout}/ecmascript4mps/languages/ecmascript4mps/org.mar9000.mps.ecmascript.build.jar" duplicate="preserve">
+      <fileset dir="${build.tmp}/java/out/org.mar9000.mps.ecmascript.build" />
+      <fileset dir="${project_home}/solutions/org.mar9000.mps.ecmascript.build/source_gen" includes="**/trace.info, **/exports, **/*.mps, **/checkpoints" />
+      <fileset dir="${build.tmp}/default/org.mar9000.mps.ecmascript.build.jar" />
+    </jar>
+    <copyModels todir="${build.tmp}/customProcessors/copyModels/solutions-org.mar9000.mps.ecmascript.build-models">
+      <fileset dir="${basedir}/solutions/org.mar9000.mps.ecmascript.build/models" includes="**/*.mps, **/*.mpsr, **/.model" />
+    </copyModels>
+    <copyModels todir="${build.tmp}/customProcessors/copyModels/solutions-org.mar9000.mps.ecmascript.build-models1">
+      <fileset dir="${project_home}/solutions/org.mar9000.mps.ecmascript.build/models" includes="**/*.mps, **/*.mpsr, **/.model" />
+    </copyModels>
+    <jar destfile="${build.layout}/ecmascript4mps/languages/ecmascript4mps/org.mar9000.mps.ecmascript.build-src.jar" duplicate="preserve">
+      <fileset dir="${project_home}/solutions/org.mar9000.mps.ecmascript.build/source_gen">
+        <exclude name="**/trace.info" />
+        <exclude name="**/exports" />
+        <exclude name="**/checkpoints" />
+        <exclude name="**/*.mps" />
+      </fileset>
+      <zipfileset file="${basedir}/solutions/org.mar9000.mps.ecmascript.build/org.mar9000.mps.ecmascript.build.msd" prefix="module" />
+      <zipfileset dir="${build.tmp}/customProcessors/copyModels/solutions-org.mar9000.mps.ecmascript.build-models" prefix="module/models" />
+      <zipfileset dir="${build.tmp}/customProcessors/copyModels/solutions-org.mar9000.mps.ecmascript.build-models1" prefix="module/models" />
+    </jar>
     <mkdir dir="${build.tmp}/default/org.mar9000.mps.ecmascript.jar1" />
     <mkdir dir="${build.tmp}/default/org.mar9000.mps.ecmascript.jar1/META-INF" />
     <echoxml file="${build.tmp}/default/org.mar9000.mps.ecmascript.jar1/META-INF/module.xml">
@@ -644,6 +684,46 @@
       <zipfileset file="${basedir}/code/languages/org.mar9000.mps.ecmascript/runtime/org.mar9000.mps.ecmascript.runtime.msd" prefix="module" />
       <zipfileset dir="${build.tmp}/customProcessors/copyModels/code-languages-org.mar9000.mps.ecmascript-runtime-models2" prefix="module/models" />
     </jar>
+    <mkdir dir="${build.tmp}/default/org.mar9000.mps.ecmascript.build.jar1" />
+    <mkdir dir="${build.tmp}/default/org.mar9000.mps.ecmascript.build.jar1/META-INF" />
+    <echoxml file="${build.tmp}/default/org.mar9000.mps.ecmascript.build.jar1/META-INF/module.xml">
+      <module namespace="org.mar9000.mps.ecmascript.build" type="solution" uuid="22ffb846-45b3-4ef5-a9f4-a67794b30a86">
+        <dependencies>
+          <module ref="422c2909-59d6-41a9-b318-40e6256b250f(jetbrains.mps.ide.build)" kind="cl" />
+        </dependencies>
+        <uses>
+          <language id="l:798100da-4f0a-421a-b991-71f8c50ce5d2:jetbrains.mps.build" />
+          <language id="l:0cf935df-4699-4e9c-a132-fa109541cba3:jetbrains.mps.build.mps" />
+          <language id="l:3600cb0a-44dd-4a5b-9968-22924406419e:jetbrains.mps.build.mps.tests" />
+        </uses>
+        <classpath>
+          <entry path="." />
+        </classpath>
+        <sources jar="org.mar9000.mps.ecmascript.build-src.jar" descriptor="org.mar9000.mps.ecmascript.build.msd" />
+      </module>
+    </echoxml>
+    <jar destfile="${build.tmp}/default/ecmascript4mps.zip/ecmascript4mps/languages/ecmascript4mps/org.mar9000.mps.ecmascript.build.jar" duplicate="preserve">
+      <fileset dir="${build.tmp}/java/out/org.mar9000.mps.ecmascript.build" />
+      <fileset dir="${project_home}/solutions/org.mar9000.mps.ecmascript.build/source_gen" includes="**/trace.info, **/exports, **/*.mps, **/checkpoints" />
+      <fileset dir="${build.tmp}/default/org.mar9000.mps.ecmascript.build.jar1" />
+    </jar>
+    <copyModels todir="${build.tmp}/customProcessors/copyModels/solutions-org.mar9000.mps.ecmascript.build-models2">
+      <fileset dir="${basedir}/solutions/org.mar9000.mps.ecmascript.build/models" includes="**/*.mps, **/*.mpsr, **/.model" />
+    </copyModels>
+    <copyModels todir="${build.tmp}/customProcessors/copyModels/solutions-org.mar9000.mps.ecmascript.build-models3">
+      <fileset dir="${project_home}/solutions/org.mar9000.mps.ecmascript.build/models" includes="**/*.mps, **/*.mpsr, **/.model" />
+    </copyModels>
+    <jar destfile="${build.tmp}/default/ecmascript4mps.zip/ecmascript4mps/languages/ecmascript4mps/org.mar9000.mps.ecmascript.build-src.jar" duplicate="preserve">
+      <fileset dir="${project_home}/solutions/org.mar9000.mps.ecmascript.build/source_gen">
+        <exclude name="**/trace.info" />
+        <exclude name="**/exports" />
+        <exclude name="**/checkpoints" />
+        <exclude name="**/*.mps" />
+      </fileset>
+      <zipfileset file="${basedir}/solutions/org.mar9000.mps.ecmascript.build/org.mar9000.mps.ecmascript.build.msd" prefix="module" />
+      <zipfileset dir="${build.tmp}/customProcessors/copyModels/solutions-org.mar9000.mps.ecmascript.build-models2" prefix="module/models" />
+      <zipfileset dir="${build.tmp}/customProcessors/copyModels/solutions-org.mar9000.mps.ecmascript.build-models3" prefix="module/models" />
+    </jar>
     <mkdir dir="${build.tmp}/default/org.mar9000.mps.ecmascript.jar3" />
     <mkdir dir="${build.tmp}/default/org.mar9000.mps.ecmascript.jar3/META-INF" />
     <echoxml file="${build.tmp}/default/org.mar9000.mps.ecmascript.jar3/META-INF/module.xml">
@@ -819,7 +899,7 @@
     <delete dir="${build.layout}" />
   </target>
   
-  <target name="compileJava" depends="java.compile.org.mar9000.mps.ecmascript, java.compile.org.mar9000.mps.ecmascript#201656743169476281, java.compile.org.mar9000.mps.ecmascript.runtime, java.compile.org.mar9000.mps.ecmascript.sandbox, java.compile.org.mar9000.mps.ecmascript.tests, java.compile.org.mar9000.mps.ecmascript.migrationTests" />
+  <target name="compileJava" depends="java.compile.org.mar9000.mps.ecmascript, java.compile.org.mar9000.mps.ecmascript#201656743169476281, java.compile.org.mar9000.mps.ecmascript.runtime, java.compile.org.mar9000.mps.ecmascript.build, java.compile.org.mar9000.mps.ecmascript.sandbox, java.compile.org.mar9000.mps.ecmascript.tests, java.compile.org.mar9000.mps.ecmascript.migrationTests" />
   
   <target name="processResources" />
   
@@ -832,6 +912,7 @@
   <target name="generate" depends="declare-mps-tasks, fetchDependencies">
     <echo message="generating" />
     <generate strictMode="true" parallelMode="true" parallelThreads="8" useInplaceTransform="false" hideWarnings="false" createStaticRefs="true" fork="true" skipUnmodifiedModels="${mps.generator.skipUnmodifiedModels}">
+      <plugin path="${artifacts.mps}/plugins/mps-build" />
       <plugin path="${artifacts.mps}/plugins/mps-core" />
       <plugin path="${artifacts.mps}/plugins/mps-testing" />
       <library file="${artifacts.mps}/languages/baseLanguage/closures.runtime.jar" />
@@ -923,16 +1004,24 @@
       <library file="${artifacts.mps}/languages/tools/jetbrains.mps.tool.common.jar" />
       <library file="${artifacts.mps}/languages/util/jetbrains.mps.java.stub.jar" />
       <library file="${artifacts.mps}/languages/util/jetbrains.mps.kernel.jar" />
+      <library file="${artifacts.mps}/languages/util/jetbrains.mps.lang.makeup.jar" />
       <library file="${artifacts.mps}/languages/util/jetbrains.mps.project.jar" />
       <library file="${artifacts.mps}/languages/util/jetbrains.mps.refactoring.jar" />
       <library file="${artifacts.mps}/languages/util/jetbrains.mps.runtime.jar" />
       <library file="${artifacts.mps}/languages/xml/jetbrains.mps.core.xml.jar" />
+      <library file="${artifacts.mps}/plugins/mps-build/languages/build/jetbrains.mps.build.jar" />
+      <library file="${artifacts.mps}/plugins/mps-build/languages/build/jetbrains.mps.build.mps.jar" />
+      <library file="${artifacts.mps}/plugins/mps-build/languages/build/jetbrains.mps.build.mps.tests.jar" />
+      <library file="${artifacts.mps}/plugins/mps-build/languages/build/jetbrains.mps.build.workflow.jar" />
+      <library file="${artifacts.mps}/plugins/mps-build/languages/build/jetbrains.mps.build.workflow.preset.jar" />
+      <library file="${artifacts.mps}/plugins/mps-build/languages/build/jetbrains.mps.ide.build.jar" />
       <library file="${artifacts.mps}/plugins/mps-testing/languages/baseLanguage/jetbrains.mps.baseLanguage.unitTest.jar" />
       <library file="${artifacts.mps}/plugins/mps-testing/languages/languageDesign/jetbrains.mps.lang.test.jar" />
       <library file="${artifacts.mps}/plugins/mps-testing/languages/languageDesign/jetbrains.mps.lang.test.matcher.jar" />
       <library file="${artifacts.mps}/plugins/mps-testing/languages/languageDesign/jetbrains.mps.lang.test.runtime.jar" />
       <chunk>
         <module file="${basedir}/code/languages/org.mar9000.mps.ecmascript/org.mar9000.mps.ecmascript.mpl" />
+        <module file="${basedir}/solutions/org.mar9000.mps.ecmascript.build/org.mar9000.mps.ecmascript.build.msd" />
       </chunk>
       <chunk>
         <module file="${basedir}/solutions/org.mar9000.mps.ecmascript.migrationTests/org.mar9000.mps.ecmascript.migrationTests.msd" />
@@ -1060,6 +1149,18 @@
       <compilerarg value="-Xlint:none" />
       <src>
         <path location="${project_home}/code/languages/org.mar9000.mps.ecmascript/runtime/source_gen" />
+      </src>
+      <classpath />
+    </javac>
+  </target>
+  
+  <target name="java.compile.org.mar9000.mps.ecmascript.build">
+    <mkdir dir="${project_home}/solutions/org.mar9000.mps.ecmascript.build/source_gen" />
+    <mkdir dir="${build.tmp}/java/out/org.mar9000.mps.ecmascript.build" />
+    <javac destdir="${build.tmp}/java/out/org.mar9000.mps.ecmascript.build" fork="true" encoding="utf8" includeantruntime="false" debug="true">
+      <compilerarg value="-Xlint:none" />
+      <src>
+        <path location="${project_home}/solutions/org.mar9000.mps.ecmascript.build/source_gen" />
       </src>
       <classpath />
     </javac>
@@ -1297,6 +1398,7 @@
     </path>
     <pathconvert pathsep="${path.separator}" property="mps.libraries.path.string" refid="mps.libraries.path" />
     <path id="mps.plugins.path">
+      <pathelement location="${artifacts.mps}/plugins/mps-build" />
       <pathelement location="${artifacts.mps}/plugins/mps-core" />
       <pathelement location="${artifacts.mps}/plugins/mps-testing" />
       <pathelement location="${build.layout}/ecmascript4mps" />
@@ -1361,6 +1463,7 @@
   <target name="cleanSources">
     <delete dir="${project_home}/code/languages/org.mar9000.mps.ecmascript/source_gen" />
     <delete dir="${project_home}/code/languages/org.mar9000.mps.ecmascript/generator/source_gen" />
+    <delete dir="${project_home}/solutions/org.mar9000.mps.ecmascript.build/source_gen" />
     <delete dir="${project_home}/solutions/org.mar9000.mps.ecmascript.migrationTests/source_gen" />
     <delete dir="${project_home}/code/languages/org.mar9000.mps.ecmascript/runtime/source_gen" />
     <delete dir="${project_home}/code/languages/org.mar9000.mps.ecmascript/sandbox/source_gen" />

--- a/build.xml
+++ b/build.xml
@@ -5,7 +5,7 @@
   <property name="build.mps.system.path" location="${build.dir}/system" />
   <property name="build.tmp" location="${build.dir}/tmp/ecmascript4mps" />
   <property name="build.layout" location="${build.dir}/artifacts/ecmascript4mps" />
-  <property name="mps_home" location="${basedir}/../../MPS/MPS-2020.1" />
+  <property name="mps_home" location="${basedir}/../../MPS/MPS-2020.2" />
   <property name="project_home" location="${basedir}" />
   <property name="mps.macro.project_home" location="${project_home}" />
   <property name="artifacts.mps" location="${mps_home}" />
@@ -16,6 +16,10 @@
   <property name="mps.teamcity.buildConfName" value="${import.mps.mps.teamcity.buildConfName}" />
   <property name="mps.idea.platform.build.number" value="${import.mps.mps.idea.platform.build.number}" />
   <property name="mps.mps.build.counter" value="${import.mps.mps.mps.build.counter}" />
+  <property name="mpsBootstrapCore.version.major" value="${import.mps.mpsBootstrapCore.version.major}" />
+  <property name="mpsBootstrapCore.version.minor" value="${import.mps.mpsBootstrapCore.version.minor}" />
+  <property name="mpsBootstrapCore.version.bugfixNr" value="${import.mps.mpsBootstrapCore.version.bugfixNr}" />
+  <property name="mpsBootstrapCore.version.eap" value="${import.mps.mpsBootstrapCore.version.eap}" />
   <property name="mpsBootstrapCore.version" value="${import.mps.mpsBootstrapCore.version}" />
   <property name="environment" value="env" />
   <property name="env.JAVA_HOME" value="${java.home}/.." />
@@ -799,7 +803,7 @@
       <zipfileset file="${basedir}/plugin.xml" prefix="ecmascript4mps/META-INF" />
       <fileset dir="${build.tmp}/default/ecmascript4mps.zip" />
     </zip>
-    <echo file="${build.layout}/build.properties">mps.build.number=${mps.build.number}${line.separator}mps.date=${mps.date}${line.separator}mps.build.vcs.number=${mps.build.vcs.number}${line.separator}mps.teamcity.buildConfName=${mps.teamcity.buildConfName}${line.separator}mps.idea.platform.build.number=${mps.idea.platform.build.number}${line.separator}mps.mps.build.counter=${mps.mps.build.counter}${line.separator}mpsBootstrapCore.version=${mpsBootstrapCore.version}</echo>
+    <echo file="${build.layout}/build.properties">mps.build.number=${mps.build.number}${line.separator}mps.date=${mps.date}${line.separator}mps.build.vcs.number=${mps.build.vcs.number}${line.separator}mps.teamcity.buildConfName=${mps.teamcity.buildConfName}${line.separator}mps.idea.platform.build.number=${mps.idea.platform.build.number}${line.separator}mps.mps.build.counter=${mps.mps.build.counter}${line.separator}mpsBootstrapCore.version.major=${mpsBootstrapCore.version.major}${line.separator}mpsBootstrapCore.version.minor=${mpsBootstrapCore.version.minor}${line.separator}mpsBootstrapCore.version.bugfixNr=${mpsBootstrapCore.version.bugfixNr}${line.separator}mpsBootstrapCore.version.eap=${mpsBootstrapCore.version.eap}${line.separator}mpsBootstrapCore.version=${mpsBootstrapCore.version}</echo>
   </target>
   
   <target name="buildDependents" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -3,9 +3,9 @@
   <name>ecmascript4mps</name>
   <category>Custom Languages</category>
   <description>MPS Ecma script support</description>
-  <version>2.8</version>
+  <version>2.9</version>
   <vendor url="http://www.mar9000.org" logo="/MPS_16.png">Marco Lombardo</vendor>
-  <idea-version since-build="201.1" until-build="202.1"/>
+  <idea-version since-build="201.1" until-build="203.1"/>
 
   <depends>jetbrains.mps.core</depends>
 

--- a/solutions/org.mar9000.mps.ecmascript.build/models/org/mar9000/mps/ecmascript/build.mps
+++ b/solutions/org.mar9000.mps.ecmascript.build/models/org/mar9000/mps/ecmascript/build.mps
@@ -120,6 +120,9 @@
         <child id="763829979718664967" name="files" index="3rtmxm" />
       </concept>
       <concept id="5507251971038816436" name="jetbrains.mps.build.mps.structure.BuildMps_Generator" flags="ng" index="1yeLz9" />
+      <concept id="4278635856200817744" name="jetbrains.mps.build.mps.structure.BuildMps_ModuleModelRoot" flags="ng" index="1BupzO">
+        <child id="8137134783396676835" name="location" index="1HemKq" />
+      </concept>
       <concept id="3189788309731840247" name="jetbrains.mps.build.mps.structure.BuildMps_Solution" flags="ng" index="1E1JtA">
         <property id="269707337715731330" name="sourcesKind" index="aoJFB" />
       </concept>
@@ -231,6 +234,9 @@
       <node concept="m$_yC" id="1KcYDCsMleN" role="m$_yJ">
         <ref role="m$_y1" to="ffeo:4k71ibbKLe8" resolve="jetbrains.mps.core" />
       </node>
+      <node concept="m$_yC" id="FNyxEXk8N9" role="m$_yJ">
+        <ref role="m$_y1" to="ffeo:5HVSRHdVm9a" resolve="jetbrains.mps.build" />
+      </node>
       <node concept="3_J27D" id="1KcYDCsMleO" role="m_cZH">
         <node concept="3Mxwew" id="1KcYDCsMleP" role="3MwsjC">
           <property role="3MwjfP" value="ecmascript4mps" />
@@ -245,9 +251,9 @@
     <node concept="2G$12M" id="1KcYDCsMleG" role="3989C9">
       <property role="TrG5h" value="ecmascript4mps" />
       <node concept="1E1JtD" id="1KcYDCsMlez" role="2G$12L">
-        <property role="BnDLt" value="true" />
         <property role="TrG5h" value="org.mar9000.mps.ecmascript" />
         <property role="3LESm3" value="a4829704-6b1b-4b3f-8122-a4a2e6ac90ff" />
+        <property role="BnDLt" value="true" />
         <node concept="55IIr" id="1KcYDCsMlet" role="3LF7KH">
           <node concept="2Ry0Ak" id="1KcYDCsMleu" role="iGT6I">
             <property role="2Ry0Am" value="code" />
@@ -341,9 +347,9 @@
         </node>
       </node>
       <node concept="1E1JtA" id="1KcYDCsMleF" role="2G$12L">
-        <property role="BnDLt" value="true" />
         <property role="TrG5h" value="org.mar9000.mps.ecmascript.runtime" />
         <property role="3LESm3" value="8b4ab1de-2aad-4e60-8dee-350cb83d3086" />
+        <property role="BnDLt" value="true" />
         <node concept="55IIr" id="1KcYDCsMle$" role="3LF7KH">
           <node concept="2Ry0Ak" id="1KcYDCsMle_" role="iGT6I">
             <property role="2Ry0Am" value="code" />
@@ -380,6 +386,45 @@
                 </node>
               </node>
             </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtA" id="FNyxEXk8Ej" role="2G$12L">
+        <property role="TrG5h" value="org.mar9000.mps.ecmascript.build" />
+        <property role="3LESm3" value="22ffb846-45b3-4ef5-a9f4-a67794b30a86" />
+        <property role="BnDLt" value="true" />
+        <node concept="1BupzO" id="FNyxEXk8Mu" role="3bR31x">
+          <node concept="3LXTmp" id="FNyxEXk8Mw" role="1HemKq">
+            <node concept="55IIr" id="FNyxEXk8My" role="3LXTmr">
+              <node concept="2Ry0Ak" id="FNyxEXk8ML" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="FNyxEXk8MQ" role="2Ry0An">
+                  <property role="2Ry0Am" value="org.mar9000.mps.ecmascript.build" />
+                  <node concept="2Ry0Ak" id="FNyxEXk8MV" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="FNyxEXk8MX" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="55IIr" id="FNyxEXk8Em" role="3LF7KH">
+          <node concept="2Ry0Ak" id="FNyxEXk8Ff" role="iGT6I">
+            <property role="2Ry0Am" value="solutions" />
+            <node concept="2Ry0Ak" id="FNyxEXk8Fk" role="2Ry0An">
+              <property role="2Ry0Am" value="org.mar9000.mps.ecmascript.build" />
+              <node concept="2Ry0Ak" id="FNyxEXk8Fp" role="2Ry0An">
+                <property role="2Ry0Am" value="org.mar9000.mps.ecmascript.build.msd" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="FNyxEXk8Gn" role="3bR37C">
+          <node concept="3bR9La" id="FNyxEXk8Go" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:78GwwOvB3tw" resolve="jetbrains.mps.ide.build" />
           </node>
         </node>
       </node>

--- a/solutions/org.mar9000.mps.ecmascript.build/models/org/mar9000/mps/ecmascript/build.mps
+++ b/solutions/org.mar9000.mps.ecmascript.build/models/org/mar9000/mps/ecmascript/build.mps
@@ -152,7 +152,7 @@
             <node concept="2Ry0Ak" id="4r6EV_1x6oC" role="2Ry0An">
               <property role="2Ry0Am" value="MPS" />
               <node concept="2Ry0Ak" id="4r6EV_1x6oH" role="2Ry0An">
-                <property role="2Ry0Am" value="MPS-2020.1" />
+                <property role="2Ry0Am" value="MPS-2020.2" />
               </node>
             </node>
           </node>
@@ -222,7 +222,7 @@
       </node>
       <node concept="3_J27D" id="1KcYDCsMleK" role="m$_w8">
         <node concept="3Mxwew" id="1KcYDCsMleL" role="3MwsjC">
-          <property role="3MwjfP" value="2.8" />
+          <property role="3MwjfP" value="2.9" />
         </node>
       </node>
       <node concept="m$f5U" id="1KcYDCsMleM" role="m$_yh">

--- a/solutions/org.mar9000.mps.ecmascript.build/models/org/mar9000/mps/ecmascript/build.mps
+++ b/solutions/org.mar9000.mps.ecmascript.build/models/org/mar9000/mps/ecmascript/build.mps
@@ -121,6 +121,8 @@
       </concept>
       <concept id="5507251971038816436" name="jetbrains.mps.build.mps.structure.BuildMps_Generator" flags="ng" index="1yeLz9" />
       <concept id="4278635856200817744" name="jetbrains.mps.build.mps.structure.BuildMps_ModuleModelRoot" flags="ng" index="1BupzO">
+        <property id="8137134783396907368" name="convert2binary" index="1Hdu6h" />
+        <property id="8137134783396676838" name="extracted" index="1HemKv" />
         <child id="8137134783396676835" name="location" index="1HemKq" />
       </concept>
       <concept id="3189788309731840247" name="jetbrains.mps.build.mps.structure.BuildMps_Solution" flags="ng" index="1E1JtA">
@@ -394,6 +396,8 @@
         <property role="3LESm3" value="22ffb846-45b3-4ef5-a9f4-a67794b30a86" />
         <property role="BnDLt" value="true" />
         <node concept="1BupzO" id="FNyxEXk8Mu" role="3bR31x">
+          <property role="1HemKv" value="true" />
+          <property role="1Hdu6h" value="true" />
           <node concept="3LXTmp" id="FNyxEXk8Mw" role="1HemKq">
             <node concept="55IIr" id="FNyxEXk8My" role="3LXTmr">
               <node concept="2Ry0Ak" id="FNyxEXk8ML" role="iGT6I">


### PR DESCRIPTION
Currently it is not possible to import the build script of ecmascript4mps into another external build script because it is not included in the plugin. This pull request allows to export it in the plugin.

Migration to 2020.2 is also included.